### PR TITLE
ci: use explicit ruff check subcommand

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install -r requirements.txt
       - name: Run ruff
-        run: ruff .
+        run: ruff check .
       - name: Run isort
         run: isort --check .
       - name: Run mypy

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ poetry run pytest
 
 ```shell
 poetry run isort .
-poetry run ruff . 
+poetry run ruff check .
 poetry run mypy .
 ```
 


### PR DESCRIPTION
## Problem

CI fails on the "Run ruff" step after the ruff version bump:

```
error: unrecognized subcommand '.'
```

## Cause

Recent ruff releases dropped the implicit alias that ran `check` when no subcommand was given, so `ruff .` no longer works.

## Fix

Use `ruff check .` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)