### PR TITLE
ci: fix lint errors surfaced by the ruff 0.16 upgrade

### DIFF
--- a/admin_form_action/__init__.py
+++ b/admin_form_action/__init__.py
@@ -14,7 +14,7 @@ _ACTION_SUBMIT_PARAMETER: Final = 'perform'
 class _FormMixin(forms.Form):
     def __init__(self, *args, **kwargs):
         self.queryset = kwargs.pop('queryset')
-        super(_FormMixin, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields[ACTION_CHECKBOX_NAME] = (
             forms.CharField(widget=forms.MultipleHiddenInput)
         )
@@ -25,7 +25,7 @@ FormT = TypeVar('FormT', bound=forms.Form)
 ModelAdminT = TypeVar('ModelAdminT', bound=ModelAdmin)
 
 
-class InjectedHttpRequest(Generic[FormT], HttpRequest):
+class InjectedHttpRequest(HttpRequest, Generic[FormT]):
     form: FormT
 
 
@@ -40,7 +40,7 @@ class Decorator(Generic[ModelAdminT, FormT]):
     default_form_template: Final = 'admin_form_action/form.html'
 
     def __init__(self, form_class: Type[FormT], form_template: Optional[str] = None):
-        form_class_name = '_Action%s' % form_class.__name__
+        form_class_name = f'_Action{form_class.__name__}'
         self.form_class = type(form_class_name, (_FormMixin, form_class), {})
         self.form_template = form_template
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,15 @@ mypy = "*"
 django-stubs = {extras = ["compatible-mypy"], version = "*"}
 django-stubs-ext = "*"
 
+[tool.ruff]
+target-version = "py38"
+
+[tool.ruff.lint]
+# The project still supports Python 3.8, so don't suggest annotation
+# styles that require a newer runtime (PEP 585 / PEP 604) or that need
+# `from __future__ import annotations` to stay safe.
+ignore = ["FA100"]
+
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
 


### PR DESCRIPTION
## Context

#21 (Renovate) bumps ruff from 0.0.292 to 0.16.2. That's a huge jump, and newer ruff enables several rules by default that this codebase never saw before.

Without an explicit `target-version`, ruff assumed the newest supported Python and wanted to rewrite the code to `list[...]` / `X | None` (PEP 585 / PEP 604) — syntax that is **not valid at runtime on Python 3.8/3.9**, which this project still supports (`python = "^3.8"` in `pyproject.toml`, no `from __future__ import annotations` anywhere). Blindly applying `ruff --fix` here would have broken the 3.8/3.9 CI jobs.

## Fix

- Add `target-version = "py38"` so ruff stops suggesting syntax the project doesn't support.
- Ignore `FA100` (which suggests adding `from __future__ import annotations` to unlock that syntax safely) — keeping `Optional`/`List`/`Type` as-is rather than reshaping the typing style across the codebase in the same PR.
- Apply the remaining fixes that are safe on every supported Python version: zero-arg `super()`, `Generic[]` moved to the last base class, and an f-string instead of `%`-formatting.

This PR targets `master` directly (independent of the ruff version bump) so that once it's merged and #21's branch is updated, its CI will already be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)